### PR TITLE
(4-1)(4-2)　初級 日付フォーマット・価格フォーマット

### DIFF
--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -101,7 +101,7 @@
 							      入社日
 							    </th>
 							    <td>
-							      <span th:utext="${employee.hireDate}">2012/11/29</span>
+							      <span th:utext="${#dates.format(employee.hireDate, 'yyyy年MM月dd日')}">2012/11/29</span>
 							    </td>
 							  </tr>
 							  <tr>
@@ -141,7 +141,7 @@
 							      給料
 							    </th>
 							    <td>
-							      <span th:utext="${employee.salary + '円'}">400000円</span>
+							      <span th:utext="${#numbers.formatInteger(employee.salary, 3, 'COMMA') + '円'}">400000円</span>
 							    </td>
 							  </tr>
 							  <tr>


### PR DESCRIPTION
従業員詳細画面の入社日をyyyy年MM月dd日形式に、給料を３桁区切りのカンマ形式に修正いたしました。

ご確認のほどよろしくお願いいたします。